### PR TITLE
Added a Use In CMS section

### DIFF
--- a/Composite-KEM-2023.asn
+++ b/Composite-KEM-2023.asn
@@ -94,6 +94,7 @@ kema-CompositeKEM {
          VALUE CompositeCiphertextValue
          PARAMS ARE absent
          PUBLIC-KEYS { publicKeyType } 
+         SMIME-CAPS { IDENTIFIED BY id }
         }
 
 
@@ -281,5 +282,24 @@ kema-MLKEM1024-X448-KMAC256 KEM-ALGORITHM ::=
     kema-CompositeKEM{
       id-MLKEM1024-X448-KMAC256, 
       pk-MLKEM1024-X448-KMAC256 }
+
+
+--
+-- Expand the S/MIME capabilities set used by CMS [RFC5911]
+--
+
+SMimeCaps SMIME-CAPS ::=
+    { kema-MLKEM512-ECDH-P256-KMAC128 |
+      kema-MLKEM512-ECDH-brainpoolP256r1-KMAC128 |
+      kema-MLKEM512-X25519-KMAC128 |
+      kema-MLKEM512-RSA2048-KMAC128 |
+      kema-MLKEM512-RSA3072-KMAC128 |
+      kema-MLKEM768-ECDH-P256-KMAC256 |
+      kema-MLKEM768-ECDH-brainpoolP256r1-KMAC256 |
+      kema-MLKEM768-X25519-KMAC256 |
+      kema-MLKEM1024-ECDH-P384-KMAC256 |
+      kema-MLKEM1024-ECDH-brainpoolP384r1-KMAC256 |
+      kema-MLKEM1024-X448-KMAC256,
+      ... }
 
 END

--- a/Composite-KEM-2023.asn
+++ b/Composite-KEM-2023.asn
@@ -289,17 +289,17 @@ kema-MLKEM1024-X448-KMAC256 KEM-ALGORITHM ::=
 --
 
 SMimeCaps SMIME-CAPS ::=
-    { kema-MLKEM512-ECDH-P256-KMAC128 |
-      kema-MLKEM512-ECDH-brainpoolP256r1-KMAC128 |
-      kema-MLKEM512-X25519-KMAC128 |
-      kema-MLKEM512-RSA2048-KMAC128 |
-      kema-MLKEM512-RSA3072-KMAC128 |
-      kema-MLKEM768-ECDH-P256-KMAC256 |
-      kema-MLKEM768-ECDH-brainpoolP256r1-KMAC256 |
-      kema-MLKEM768-X25519-KMAC256 |
-      kema-MLKEM1024-ECDH-P384-KMAC256 |
-      kema-MLKEM1024-ECDH-brainpoolP384r1-KMAC256 |
-      kema-MLKEM1024-X448-KMAC256,
+    { kema-MLKEM512-ECDH-P256-KMAC128.&smimeCaps |
+      kema-MLKEM512-ECDH-brainpoolP256r1-KMAC128.&smimeCaps |
+      kema-MLKEM512-X25519-KMAC128.&smimeCaps |
+      kema-MLKEM512-RSA2048-KMAC128.&smimeCaps |
+      kema-MLKEM512-RSA3072-KMAC128.&smimeCaps |
+      kema-MLKEM768-ECDH-P256-KMAC256.&smimeCaps |
+      kema-MLKEM768-ECDH-brainpoolP256r1-KMAC256.&smimeCaps |
+      kema-MLKEM768-X25519-KMAC256.&smimeCaps |
+      kema-MLKEM1024-ECDH-P384-KMAC256.&smimeCaps |
+      kema-MLKEM1024-ECDH-brainpoolP384r1-KMAC256.&smimeCaps |
+      kema-MLKEM1024-X448-KMAC256.&smimeCaps,
       ... }
 
 END

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -95,12 +95,12 @@ normative:
       org: "American National Standards Institute"
     date: 2007
     seriesinfo: American National Standard X9.44
-  # SHA3:
-  #   title: "SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions, FIPS PUB 202, DOI 10.6028/NIST.FIPS.202"
-  #   author:
-  #     org: "National Institute of Standards and Technology (NIST)"
-  #   date: August 2015
-  #   target: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
+  SHA3:
+    title: "SHA-3 Standard: Permutation-Based Hash and Extendable-Output Functions, FIPS PUB 202, DOI 10.6028/NIST.FIPS.202"
+    author:
+      org: "National Institute of Standards and Technology (NIST)"
+    date: August 2015
+    target: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.202.pdf
   SP800-185:
     title: "SHA-3 Derived Functions: cSHAKE, KMAC, TupleHash and ParallelHash"
     author:
@@ -143,6 +143,7 @@ informative:
   RFC2986:
   RFC4210:
   RFC4211:
+  RFC5083:
   RFC5639:
   RFC5914:
   RFC6090:
@@ -589,7 +590,62 @@ As with the other composite KEM algorithms, when `id-MLKEM512-RSA2048-KMAC128` o
 where:
 
 * `kda-kdf3` is defined in {{I-D.ietf-lamps-rfc5990bis}} which references it from [ANS-X9.44].
+* `id-sha3-256` is defined in {{I-D.housley-lamps-cms-sha3-hash}} which references it from [SHA3].
 
+
+# Use in CMS
+
+Composite KEM algorithms MAY be employed for one or more recipients in the CMS enveloped-data content type [RFC5652], the CMS authenticated-data content type [RFC5652], or the CMS authenticated-enveloped-data content type [RFC5083]. In each case, the KEMRecipientInfo [I-D.ietf-lamps-cms-kemri] is used with with the chosen composite KEM Algorithm to securely transfer the content-encryption key from the originator to the recipient.
+
+## Underlying Components
+
+A CMS implementation that supports a composite KEM algorithm MUST support at least the following underlying components:
+
+For the key-derivation function, an implementation MUST support KDF3 [ANS-X9.44] with id-sha3-256 {{I-D.housley-lamps-cms-sha3-hash}}.
+
+For key-wrapping, an implementation MUST support the AES-Wrap-128 [RFC3394] key-encryption algorithm.
+
+An implementation MAY also support other key-derivation functions and other key-encryption algorithms as well.
+
+## RecipientInfo Conventions
+
+When a composite KEM Algorithm is employed for a recipient, the RecipientInfo alternative for that recipient MUST be OtherRecipientInfo using the KEMRecipientInfo structure [I-D.ietf-lamps-cms-kemri]. The fields of the KEMRecipientInfo MUST have the following values:
+
+`version` is the syntax version number; it MUST be 0.
+
+`rid` identifies the recipient's certificate or public key.
+
+`kem` identifies the KEM algorithm; it MUST contain one of the OIDs listed in {{tab-kem-algs}}.
+
+`kemct` is the ciphertext produced for this recipient; it contains the `ct` output from `Encaps(pk)`.
+
+`kdf` identifies the key-derivation function (KDF). Note that the KDF used for CMS RecipientInfo process MAY be different than the KDF used within the composite KEM Algorithm.
+
+`kekLength` is the size of the key-encryption key in octets.
+
+`ukm` is an optional random input to the key-derivation function.
+
+`wrap` identifies a key-encryption algorithm used to encrypt the keying material.
+
+`encryptedKey` is the result of encrypting the keying material with the key-encryption key. When used with the CMS enveloped-data content type [RFC5652], the keying material is a content-encryption key. When used with the CMS authenticated-data content type [RFC5652], the keying material is a message-authentication key. When used with the CMS authenticated-enveloped-data content type [RFC5083], the keying material is a content-authenticated-encryption key.
+
+## Certificate Conventions
+The conventions specified in this section augment RFC 5280 [RFC5280].
+
+The willingness to accept a composite KEM Algorithm MAY be signaled by the use of the SMIMECapabilities Attribute as specified in Section 2.5.2. of [RFC8551] or the SMIMECapabilities certificate extension as specified in [RFC4262].
+
+The intended application for the public key MAY be indicated in the key usage certificate extension as specified in Section 4.2.1.3 of [RFC5280]. If the keyUsage extension is present in a certificate that conveys a composite KEM public key, then the key usage extension MUST contain only the following value:
+
+keyEncipherment
+
+The digitalSignatrure and dataEncipherment values MUST NOT be present. That is, a public key intended to be employed only with a composite KEM algorithm MUST NOT also be employed for data encryption or for digital signatures. This requirement does not carry any particular security consideration; only the convention that KEM keys be identifed with the `keyEncipherment` key usage.
+
+
+## SMIMECapabilities Attribute Conventions
+
+Section 2.5.2 of [RFC8551] defines the SMIMECapabilities attribute to announce a partial list of algorithms that an S/MIME implementation can support. When constructing a CMS signed-data content type [RFC5652], a compliant implementation MAY include the SMIMECapabilities attribute that announces support for the RSA-KEM Algorithm.
+
+The SMIMECapability SEQUENCE representing a composite KEM Algorithm MUST include the appropriate object identifier as per {{tab-kem-algs}} in the capabilityID field.
 
 # ASN.1 Module {#sec-asn1-module}
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -626,7 +626,7 @@ When a composite KEM Algorithm is employed for a recipient, the RecipientInfo al
 
 `kemct` is the ciphertext produced for this recipient; it contains the `ct` output from `Encaps(pk)`.
 
-`kdf` identifies the key-derivation function (KDF). Note that the KDF used for CMS RecipientInfo process MAY be different than the KDF used within the composite KEM Algorithm.
+`kdf` identifies the key-derivation function (KDF). Note that the KDF used for CMS RecipientInfo process MAY be different than the KDF used within the composite KEM Algorithm, which MAY be different than the KDFs (if any) used within the component KEMs of the composite KEM Algorithm.
 
 `kekLength` is the size of the key-encryption key in octets.
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -619,7 +619,7 @@ where:
 
 # Use in CMS
 
-EDNOTE: The convention in LAMPS is to specify algorithms and their CMS conventions in separate documents. Here we have presented them in the same document, but this section has been written so that it can easily be moved to a standalone document.
+\[EDNOTE: The convention in LAMPS is to specify algorithms and their CMS conventions in separate documents. Here we have presented them in the same document, but this section has been written so that it can easily be moved to a standalone document.\]
 
 Composite KEM algorithms MAY be employed for one or more recipients in the CMS enveloped-data content type [RFC5652], the CMS authenticated-data content type [RFC5652], or the CMS authenticated-enveloped-data content type [RFC5083]. In each case, the KEMRecipientInfo [I-D.ietf-lamps-cms-kemri] is used with the chosen composite KEM Algorithm to securely transfer the content-encryption key from the originator to the recipient.
 
@@ -629,14 +629,14 @@ A CMS implementation that supports a composite KEM algorithm MUST support at lea
 
 When a particular Composite KEM OID is supported, an implementation MUST support the corresponding KDF algorithm identifier in {{tab-cms-kdf-wrap}}.
 
-When a particular Composite KEM OID is supported, an implementation MUST support the corresponding WRAP algorithm identifier in {{tab-cms-kdf-wrap}}.
+When a particular Composite KEM OID is supported, an implementation MUST support the corresponding key-encryption algorithm identifier in {{tab-cms-kdf-wrap}}.
 
 An implementation MAY also support other key-derivation functions and other key-encryption algorithms as well.
 
-The following table lists the REQUIRED KDF and WRAP algorithms to preserve security and performance characteristics of each composite algorithm.
+The following table lists the REQUIRED KDF and key-encryption algorithms to preserve security and performance characteristics of each composite algorithm.
 
 
-| Composite KEM OID                         | KDF                       | WRAP             |
+| Composite KEM OID                         | KDF                       | Key Encryption Alg |
 |---------                                  | ---                       | ---              |
 | id-MLKEM512-ECDH-P256-KMAC128             | id-alg-hkdf-with-sha3-256 | id-aes128-Wrap   |
 | id-MLKEM512-ECDH-brainpoolP256r1-KMAC128  | id-alg-hkdf-with-sha3-256 | id-aes128-Wrap   |
@@ -658,9 +658,8 @@ where:
 * `id-alg-hkdf-with-sha3-*` are defined in {{I-D.ietf-lamps-cms-sha3-hash}}.
 * `id-aes*-Wrap` are defined in [RFC3394].
 
-Implementors MAY safely substitute stronger KDF and WRAP algorithms than those indicated; for example `id-alg-hkdf-with-sha3-512` and `id-aes256-Wrap` MAY be safely used in place of `id-alg-hkdf-with-sha3-384`and `id-aes192-Wrap`, for example, where SHA3-384 or AES-192 are not supported.
+Implementors MAY safely substitute stronger KDF and key-encryption algorithms than those indicated; for example `id-alg-hkdf-with-sha3-512` and `id-aes256-Wrap` MAY be safely used in place of `id-alg-hkdf-with-sha3-384`and `id-aes192-Wrap`, for example, where SHA3-384 or AES-192 are not supported.
 
-Implementors MAY salefy substitute different symmetric algorithms of equivalent strength. For example SHA-3 MAY be replaced by the equivalent strength SHA-2, or the HKDF-based algorithms MAY be replaced by an equivalent strength KDF based on a different construction, such as KDF3.
 
 ## RecipientInfo Conventions
 
@@ -672,7 +671,7 @@ When a composite KEM Algorithm is employed for a recipient, the RecipientInfo al
 
 `kem` identifies the KEM algorithm; it MUST contain one of the OIDs listed in {{tab-kem-algs}}.
 
-`kemct` is the ciphertext produced for this recipient; it contains the `ct` output from `Encaps(pk)`.
+`kemct` is the ciphertext produced for this recipient; it contains the `ct` output from `Encaps(pk)` of the KEM algorithm identified in the `kem` parameter.
 
 `kdf` identifies the key-derivation function (KDF). Note that the KDF used for CMS RecipientInfo process MAY be different than the KDF used within the composite KEM Algorithm, which MAY be different than the KDFs (if any) used within the component KEMs of the composite KEM Algorithm.
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -572,7 +572,7 @@ where:
 
 # Use in CMS
 
-Composite KEM algorithms MAY be employed for one or more recipients in the CMS enveloped-data content type [RFC5652], the CMS authenticated-data content type [RFC5652], or the CMS authenticated-enveloped-data content type [RFC5083]. In each case, the KEMRecipientInfo [I-D.ietf-lamps-cms-kemri] is used with with the chosen composite KEM Algorithm to securely transfer the content-encryption key from the originator to the recipient.
+Composite KEM algorithms MAY be employed for one or more recipients in the CMS enveloped-data content type [RFC5652], the CMS authenticated-data content type [RFC5652], or the CMS authenticated-enveloped-data content type [RFC5083]. In each case, the KEMRecipientInfo [I-D.ietf-lamps-cms-kemri] is used with the chosen composite KEM Algorithm to securely transfer the content-encryption key from the originator to the recipient.
 
 ## Underlying Components
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -587,7 +587,7 @@ When a particular Composite KEM OID is supported, an implementation MUST support
 
 An implementation MAY also support other key-derivation functions and other key-encryption algorithms as well.
 
-The following table lists the RECOMMENDED KDF and WRAP algorithms to preserve security and performance characteristics of each composite algorithm.
+The following table lists the REQUIRED KDF and WRAP algorithms to preserve security and performance characteristics of each composite algorithm.
 
 
 | Composite KEM OID                         | KDF                       | WRAP             |
@@ -603,14 +603,16 @@ The following table lists the RECOMMENDED KDF and WRAP algorithms to preserve se
 | id-MLKEM1024-ECDH-P384-KMAC256            | id-alg-hkdf-with-sha3-512 | id-aes256-Wrap   |
 | id-MLKEM1024-ECDH-brainpoolP384r1-KMAC256 | id-alg-hkdf-with-sha3-512 | id-aes256-Wrap   |
 | id-MLKEM1024-X448-KMAC256                 | id-alg-hkdf-with-sha3-512 | id-aes256-Wrap   |
-{: #tab-cms-kdf-wrap title="RECOMMENDED pairings for CMS KDF and WRAP"}
+{: #tab-cms-kdf-wrap title="REQUIRED pairings for CMS KDF and WRAP"}
+
+\[EDNOTE: OIDs for KMAC-based KDFs are expected. Should they be used in place of the HKDF-with-sha3 OIDs above?]
 
 where:
 
 * `id-alg-hkdf-with-sha3-*` are defined in {{I-D.ietf-lamps-cms-sha3-hash}}.
 * `id-aes*-Wrap` are defined in [RFC3394].
 
-Implementors MAY safely substutite stronger KDF and WRAP algorithms than those indicated; for example `id-alg-hkdf-with-sha3-512` and `id-aes256-Wrap` MAY be safely used in place of `id-alg-hkdf-with-sha3-384`and `id-aes192-Wrap`, for example, where SHA3-384 or AES-192 are not supported.
+Implementors MAY safely substitute stronger KDF and WRAP algorithms than those indicated; for example `id-alg-hkdf-with-sha3-512` and `id-aes256-Wrap` MAY be safely used in place of `id-alg-hkdf-with-sha3-384`and `id-aes192-Wrap`, for example, where SHA3-384 or AES-192 are not supported.
 
 Implementors MAY salefy substitute different symmetric algorithms of equivalent strength. For example SHA-3 MAY be replaced by the equivalent strength SHA-2, or the HKDF-based algorithms MAY be replaced by an equivalent strength KDF based on a different construction, such as KDF3.
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -171,32 +171,9 @@ This document assumes that all component algorithms are KEMs, and therefore it d
 
 --- middle
 
-# Changes in version -01 and -02
+# Changes in version -03
 
-Changes affecting interoperability:
-
-* Re-worked wire format and ASN.1 to remove vestiges of Generics.
-  * Changed all `SEQUENCE OF SIZE (2..MAX)` to `SEQUENCE OF SIZE (2)`.
-  * Changed the definition of `CompositeKEMPublicKey` from `SEQUENCE OF SubjectPublicKeyInfo` to `SEQUENCE OF BIT STRING` since with complete removal of Generic Composites, there is no longer any need to carry the component AlgorithmIdentifiers.
-  * Removed CompositeKEMParams since all params are now explicit in the OID.
-* Defined `KeyGen()`, `Encaps()`, and `Decaps()` for a composite KEM algorithm.
-* Removed the discussion of KeyTrans -> KEM and KeyAgree -> KEM promotions, and instead simply referenced {{I-D.ietf-lamps-rfc5990bis}} and {{I-D.ounsworth-lamps-cms-dhkem}}.
-* Made RSA keys fixed-length at 2048 and 3072, both at the NIST Level 1 / AES-128 security level.
-* Re-worked section 4.1 (id-MLKEM768-RSA3072-KMAC256) to Reference 5990bis and its updated structures.
-* Removed RSA-KEM KDF params and make them implied by the OID; ie provide a profile of 5990bis.
-* Aligned combiner with draft-ounsworth-cfrg-kem-combiners-04.
-* Added id-MLKEM512-RSA2048-KMAC128 so that we have an RSA 2048 option.
-
-Editorial changes:
-
-* Refactored to use MartinThomson github template.
-* Made this document standalone by folding in the minimum necessary content from composite-keys and dropping the cross-reference to composite-sigs.
-* Added a paragraph describing how to reconstitute component SPKIs.
-* Added an Implementation Consideration about FIPS validation where only one component algorithm is FIPS-approved.
-* Shortened the abstract (moved some content into Intro).
-* Brushed up the Security Considerations.
-* Made a proper IANA Considerations section.
-* Rename "Kyber" to "ML-KEM".
+* Added section "Use in CMS".
 
 Still to do in a future version:
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -581,7 +581,7 @@ Composite KEM algorithms MAY be employed for one or more recipients in the CMS e
 
 A CMS implementation that supports a composite KEM algorithm MUST support at least the following underlying components:
 
-For the key-derivation function, an implementation MUST support `id-alg-hkdf-with-sha3-256` {{I-D.ietf-lamps-cms-sha3-hash}}.
+When a particular Composite KEM OID is supported, an implementation MUST support the corresponding KDF algorithm identifier in {{tab-cms-kdf-wrap}}.
 
 For key-wrapping, an implementation MUST support the AES-Wrap-128 [RFC3394] key-encryption algorithm.
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -583,7 +583,7 @@ A CMS implementation that supports a composite KEM algorithm MUST support at lea
 
 When a particular Composite KEM OID is supported, an implementation MUST support the corresponding KDF algorithm identifier in {{tab-cms-kdf-wrap}}.
 
-For key-wrapping, an implementation MUST support the AES-Wrap-128 [RFC3394] key-encryption algorithm.
+When a particular Composite KEM OID is supported, an implementation MUST support the corresponding WRAP algorithm identifier in {{tab-cms-kdf-wrap}}.
 
 An implementation MAY also support other key-derivation functions and other key-encryption algorithms as well.
 

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -646,7 +646,7 @@ The intended application for the public key MAY be indicated in the key usage ce
 
 keyEncipherment
 
-The digitalSignatrure and dataEncipherment values MUST NOT be present. That is, a public key intended to be employed only with a composite KEM algorithm MUST NOT also be employed for data encryption or for digital signatures. This requirement does not carry any particular security consideration; only the convention that KEM keys be identifed with the `keyEncipherment` key usage.
+The digitalSignature and dataEncipherment values MUST NOT be present. That is, a public key intended to be employed only with a composite KEM algorithm MUST NOT also be employed for data encryption or for digital signatures. This requirement does not carry any particular security consideration; only the convention that KEM keys be identifed with the `keyEncipherment` key usage.
 
 
 ## SMIMECapabilities Attribute Conventions


### PR DESCRIPTION
Adding this section here avoids the need for a wrapper draft telling you how to use composite KEM in CMS.

Closes #12 