### PR TITLE
Fix KeyGen() and Decap() to use mlkemSeed instead of mlkemSK

### DIFF
--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -675,13 +675,13 @@ Decap Process:
   1. Separate the private keys and ciphertexts
 
       (mlkemSeed, tradSK) = DeserializePrivateKey(sk)
-      (_, mlkemSK) = MLKEM.KeyGen(mlkemSeed)
+      (_, mlkemSK) = ML-KEM.KeyGen(mlkemSeed)
       (mlkemCT, tradCT) = DeserializeCiphertext(ct)
 
   2.  Perform the respective component Encap operations according to
       their algorithm specifications.
 
-      mlkemSS = MLKEM.Decaps(mlkemSK, mlkemCT)
+      mlkemSS = ML-KEM.Decaps(mlkemSK, mlkemCT)
       tradSS  = TradKEM.Decap(tradSK, tradCT)
 
   3. If either ML-KEM.Decaps() or TradKEM.Decap() return an error,

--- a/draft-ietf-lamps-pq-composite-kem.md
+++ b/draft-ietf-lamps-pq-composite-kem.md
@@ -538,7 +538,7 @@ Key Generation Process:
   1. Generate component keys
 
     mlkemSeed = Random(64)
-    (mlkemPK, _) = ML-KEM.KeyGen(mlkemSeed)
+    (mlkemPK, mlkemSK_) = ML-KEM.KeyGen(mlkemSeed)
     (tradPK, tradSK) = Trad.KeyGen()
 
   2. Check for component key gen failure
@@ -548,7 +548,7 @@ Key Generation Process:
   3. Output the composite public and private keys
 
     pk = SerializePublicKey(mlkemPK, tradPK)
-    sk = SerializePrivateKey(mlkemSK, tradSK)
+    sk = SerializePrivateKey(mlkemSeed, tradSK)
     return (pk, sk)
 
 ~~~
@@ -674,7 +674,8 @@ Decap Process:
 
   1. Separate the private keys and ciphertexts
 
-      (mlkemSK, tradSK) = DeserializePrivateKey(sk)
+      (mlkemSeed, tradSK) = DeserializePrivateKey(sk)
+      (_, mlkemSK) = MLKEM.KeyGen(mlkemSeed)
       (mlkemCT, tradCT) = DeserializeCiphertext(ct)
 
   2.  Perform the respective component Encap operations according to


### PR DESCRIPTION
* Composite.KeyGen() returns now mlkemSeed in serialized Composite Private Key.
* Composite.Decap() now generates mlkemSK from mlkemSeed.
* Fixes function calls to ML-KEM.* in Decap().